### PR TITLE
chore: commitlint, eslint 규칙 강화

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,5 +20,33 @@ export default {
         'remove',
       ],
     ],
+    // 대문자 금지 규칙
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
+    'subject-empty': [2, 'never'],
+    'type-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'header-trim': [2, 'always'],
+
+    // 콜론 뒤 공백 필수 추가
+    'type-colon-space': [2, 'always'],
   },
+
+  // 커스텀 플러그인으로 공백 검사
+  plugins: [
+    {
+      rules: {
+        'type-colon-space': ({ raw }) => {
+          const pattern = /^[a-z]+:\s/
+          return [
+            pattern.test(raw),
+            '콜론(:) 뒤에 공백이 필요합니다. 예: "feat: 메시지"',
+          ]
+        },
+      },
+    },
+  ],
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,9 +69,37 @@ export default tseslint.config(
       ],
 
       // ===== TypeScript 규칙 =====
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error', // any 금지 (error로 강화)
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
+
+      // enum 금지 (as const 사용)
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'TSEnumDeclaration',
+          message: 'enum 대신 as const를 사용하세요.',
+        },
+      ],
+
+      // 타입/인터페이스 네이밍 규칙 (PascalCase)
+      '@typescript-eslint/naming-convention': [
+        'warn',
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'typeProperty',
+          format: ['camelCase', 'snake_case'],
+        },
+        {
+          selector: 'variable',
+          types: ['boolean'],
+          format: ['camelCase'],
+          prefix: ['is', 'has', 'should', 'can'],
+        },
+      ],
 
       // ===== React 베스트 프랙티스 =====
       'react/prop-types': 'off',
@@ -84,7 +112,36 @@ export default tseslint.config(
       // ===== 코드 품질 =====
       'no-console': 'warn',
       'no-debugger': 'warn',
-      'no-duplicate-imports': 'off', // perfectionist가 처리
+      'no-duplicate-imports': 'off',
+
+      // 주석 뒤 띄어쓰기
+      'spaced-comment': [
+        'warn',
+        'always',
+        {
+          markers: ['/'],
+          exceptions: ['-', '+', '*'],
+        },
+      ],
+
+      // return 전 빈 줄
+      'padding-line-between-statements': [
+        'warn',
+        { blankLine: 'always', prev: '*', next: 'return' },
+        { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+        {
+          blankLine: 'any',
+          prev: ['const', 'let', 'var'],
+          next: ['const', 'let', 'var'],
+        },
+      ],
+
+      // 화살표 함수 사용 권장
+      'prefer-arrow-callback': 'warn',
+      'arrow-body-style': ['warn', 'as-needed'],
+
+      // 중괄호 항상 사용
+      curly: ['warn', 'all'],
 
       // ===== Vite HMR =====
       'react-refresh/only-export-components': [


### PR DESCRIPTION
## 📌 작업 내용
팀 코드 컨벤션에 맞춰 린트 규칙을 강화했습니다.
### Commitlint 규칙 추가
- subject-case: 커밋 제목 대문자(PascalCase, UPPERCASE 등) 금지
- type-colon-space: 콜론(:) 뒤 공백 필수 (`chore:메시지` ❌ → `chore: 메시지` ✅)
- header-trim: 커밋 제목 앞뒤 공백 금지

### ESLint 규칙 추가
- spaced-comment: 주석 뒤 띄어쓰기 필수
- padding-line-between-statements: return 전 빈 줄 필수
- no-explicit-any: any 사용 금지 (error)
- enum 금지: as const 사용 권장
- naming-convention: 타입/인터페이스 PascalCase, boolean 변수 is/has 접두사
- prefer-arrow-callback: 화살표 함수 사용 권장
- curly: 중괄호 항상 사용

## 🔗 관련 이슈

- closes #27 

## 📁 변경 파일

- `commitlint.config.js`
- `eslint.config.js`
