### PR TITLE
feat: 쪽지시험 목록 페이지 구현(#52)

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,3 +21,8 @@ export { DataTableLayout } from './common/common-table/DataTableLayout'
 export { default as DropdownMenu } from './common/dropdownmenu/DropdownMenu'
 export * from './common/dropdownmenu/DropdownList'
 export * from './common/input/inputStyle'
+export * from './common/dropdownmenu/DropdownList'
+export type {
+  DropdownItem,
+  DropdownMenuProps,
+} from './common/dropdownmenu/DropdownMenu'

--- a/src/features/exam/EmptyState.tsx
+++ b/src/features/exam/EmptyState.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@components'
+
+type EmptyStateProps = {
+  onButtonClick: () => void
+}
+
+export default function EmptyState({ onButtonClick }: EmptyStateProps) {
+  return (
+    <div className="flex h-100 flex-col items-center justify-center">
+      <p className="text-[18px] text-neutral-500">등록된 시험이 없습니다.</p>
+      <p className="mt-2 text-[16px] text-text-secondary">
+        수강생들이 학습할 수 있도록 문제를 등록해주세요!
+      </p>
+      <Button
+        variant="primary"
+        className="mt-6 h-13 w-82"
+        onClick={onButtonClick}
+      >
+        시험 생성하기
+      </Button>
+    </div>
+  )
+}

--- a/src/features/exam/ExamList.tsx
+++ b/src/features/exam/ExamList.tsx
@@ -1,0 +1,35 @@
+import { Button, DataTableLayout } from '@components'
+import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+
+import type { Exam } from './utils/types.ts'
+
+import { ExamColumns } from './examConfig.tsx'
+
+type ExamListProps = {
+  data: Exam[]
+  onButtonClick: () => void
+}
+
+export default function ExamList({ data, onButtonClick }: ExamListProps) {
+  const table = useReactTable({
+    data,
+    columns: ExamColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return (
+    <>
+      <DataTableLayout table={table} />
+      <div className="mt-4 flex justify-end pr-2">
+        <Button variant="primary" size="md" onClick={onButtonClick}>
+          생성
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/src/features/exam/ExamPage.tsx
+++ b/src/features/exam/ExamPage.tsx
@@ -1,0 +1,56 @@
+import { COURSE_LIST_DROPDOWN, SUBJECT_LIST_DROPDOWN } from '@mocks'
+import { useState } from 'react'
+
+import type { Exam, ExamPageProps, Filters } from './utils/types'
+
+import EmptyState from './EmptyState'
+import ExamList from './ExamList'
+import FilterSection from './FilterSection'
+import { useSearchTerm } from './hook/useSearchTerm'
+
+export default function ExamPage({ initialData = [] }: ExamPageProps) {
+  const [filters, setFilters] = useState<Filters>({
+    course: '',
+    subject: '',
+  })
+
+  const [data, _setData] = useState<Exam[]>(initialData)
+  const { search, setSearch } = useSearchTerm()
+
+  const handleChangeFilters = (key: keyof Filters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleSearch = () => {
+    // eslint-disable-next-line no-console
+    console.log('조회', { filters, search })
+  }
+
+  const handleCreate = () => {
+    // eslint-disable-next-line no-console
+    console.log('시험 생성하기')
+  }
+
+  return (
+    <section className="p-18">
+      <h1 className="mb-1 text-[18px] text-neutral-500">쪽지시험 관리</h1>
+      <div className="mb-3">
+        <FilterSection
+          filters={filters}
+          onChangeFilters={handleChangeFilters}
+          search={search}
+          onChangeSearch={setSearch}
+          onSubmit={handleSearch}
+          courseOptions={COURSE_LIST_DROPDOWN}
+          subjectOptions={SUBJECT_LIST_DROPDOWN}
+        />
+      </div>
+
+      {data.length === 0 ? (
+        <EmptyState onButtonClick={handleCreate} />
+      ) : (
+        <ExamList data={data} onButtonClick={handleCreate} />
+      )}
+    </section>
+  )
+}

--- a/src/features/exam/FilterSection.tsx
+++ b/src/features/exam/FilterSection.tsx
@@ -1,0 +1,49 @@
+import { BaseInput, Button, type DropdownItem, DropdownMenu } from '@components'
+import { COURSE_LIST_DROPDOWN, SUBJECT_LIST_DROPDOWN } from '@mocks'
+
+import type { Filters } from './utils/types'
+
+type FilterSectionProps = {
+  filters: Filters
+  onChangeFilters: (key: keyof Filters, value: string) => void
+  search: string
+  onChangeSearch: (value: string) => void
+  onSubmit: () => void
+  courseOptions?: DropdownItem[]
+  subjectOptions?: DropdownItem[]
+}
+
+export default function FilterSection({
+  filters,
+  onChangeFilters,
+  search,
+  onChangeSearch,
+  onSubmit,
+  courseOptions = COURSE_LIST_DROPDOWN,
+  subjectOptions = SUBJECT_LIST_DROPDOWN,
+}: FilterSectionProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <DropdownMenu
+        items={courseOptions}
+        selectedValue={filters.course}
+        onSelect={(value) => onChangeFilters('course', value)}
+        placeHolder="과정"
+      />
+      <DropdownMenu
+        items={subjectOptions}
+        selectedValue={filters.subject}
+        onSelect={(value) => onChangeFilters('subject', value)}
+        placeHolder="과목"
+      />
+      <BaseInput
+        value={search}
+        onChange={(e) => onChangeSearch(e.target.value)}
+        placeholder="검색어를 입력하세요."
+      />
+      <Button variant="secondary" size="md" onClick={onSubmit}>
+        조회
+      </Button>
+    </div>
+  )
+}

--- a/src/features/exam/constants/examDropdown.ts
+++ b/src/features/exam/constants/examDropdown.ts
@@ -1,0 +1,33 @@
+import { createExamDropdown } from '../utils/createExamDropdown'
+
+/**
+ * value : 리스트 값
+ * label : 드랍다운 리스트
+ */
+const COURSE_LIST = [
+  {
+    value: 'exam_id',
+    label: '초격차 웹 개발 프론트엔드 부트캠프',
+  },
+  {
+    value: 'exam_id2',
+    label: '초격차 웹 개발 백엔드 부트캠프',
+  },
+]
+
+const SUBJECT_LIST = [
+  {
+    value: 'exam_id',
+    label: 'REACT',
+  },
+  {
+    value: 'exam_id2',
+    label: 'JAVESCRIPT',
+  },
+]
+
+/**
+ * 드롭다운 리스트
+ */
+export const COURSE_LIST_DROPDOWN = createExamDropdown(COURSE_LIST)
+export const SUBJECT_LIST_DROPDOWN = createExamDropdown(SUBJECT_LIST)

--- a/src/features/exam/examConfig.tsx
+++ b/src/features/exam/examConfig.tsx
@@ -1,0 +1,60 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { Button } from '@components'
+
+import type { Exam } from './utils/types'
+
+export const ExamColumns: ColumnDef<Exam>[] = [
+  {
+    accessorKey: 'id',
+    header: 'ID',
+    enableSorting: true,
+  },
+  {
+    accessorKey: 'title',
+    header: '제목',
+    cell: ({ row }) => (
+      <span className="cursor-pointer underline">{row.original.title}</span>
+    ),
+  },
+  {
+    accessorKey: 'subjectName',
+    header: '과목명',
+  },
+  {
+    accessorKey: 'questionCount',
+    header: '총 문제 수',
+  },
+  {
+    accessorKey: 'submitCount',
+    header: '응시 수',
+  },
+  {
+    accessorKey: 'createdAt',
+    header: '등록 일시',
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: '수정 일시',
+  },
+  {
+    id: 'actions',
+    header: '',
+    cell: ({ row }) => (
+      <div className="flex flex-row gap-3">
+        {row.original.status === 'deployed' ? (
+          <Button variant="success-light" size="sm">
+            배포중
+          </Button>
+        ) : (
+          <Button variant="success" size="sm">
+            배포
+          </Button>
+        )}
+        <Button variant="primary-light" size="sm">
+          자세히
+        </Button>
+      </div>
+    ),
+  },
+]

--- a/src/features/exam/hook/useSearchTerm.ts
+++ b/src/features/exam/hook/useSearchTerm.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export function useSearchTerm(initialValue = '') {
+  const [search, setSearch] = useState(initialValue)
+
+  const handleChangeSearch = (value: string) => {
+    setSearch(value)
+  }
+
+  const resetSearch = () => {
+    setSearch('')
+  }
+
+  return {
+    search,
+    setSearch: handleChangeSearch,
+    resetSearch,
+  }
+}

--- a/src/features/exam/index.ts
+++ b/src/features/exam/index.ts
@@ -1,1 +1,17 @@
+// exam
+export { default as FilterSection } from './FilterSection'
+export { default as EmptyState } from './EmptyState'
+export { default as ExamList } from './ExamList'
+export { default as ExamPage } from './ExamPage.tsx'
+export { ExamColumns } from './examConfig.tsx'
+export { mockExamList } from '../../mocks/mockExamList.ts'
 export { default as ExamCreate } from './ExamCreate'
+
+// types
+export * from './utils/types.ts'
+
+// hooks
+export { useSearchTerm } from './hook/useSearchTerm'
+
+// utils
+export { createExamDropdown } from './utils/createExamDropdown.ts'

--- a/src/features/exam/story/ExamCreate.stories.tsx
+++ b/src/features/exam/story/ExamCreate.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import ExamCreate from './ExamCreate'
+import ExamCreate from '../ExamCreate'
 
 const meta = {
   title: 'Modals/ExamCreate',

--- a/src/features/exam/story/ExamPage.stories.tsx
+++ b/src/features/exam/story/ExamPage.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { mockExamList } from '@mocks'
+
+import ExamPage from '../ExamPage'
+
+const meta: Meta<typeof ExamPage> = {
+  title: 'Pages/Exam/ExamPage',
+  component: ExamPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ExamPage>
+
+export const Default: Story = {}
+
+export const WithData: Story = {
+  name: '데이터가 있을 때',
+  args: {
+    initialData: mockExamList,
+  },
+}
+
+export const Empty: Story = {
+  name: '데이터가 없을 때(EmptyState',
+  args: {
+    initialData: [],
+  },
+}

--- a/src/features/exam/types.ts
+++ b/src/features/exam/types.ts
@@ -1,0 +1,19 @@
+export type Exam = {
+  id: number
+  title: string
+  subjectName: string
+  totalQuestions: number
+  submissionCount: number
+  createdAt: string
+  updatedAt: string
+  status: 'deployed' | 'pending'
+}
+
+export type Filters = {
+  course: string
+  subject: string
+}
+
+export type ExamPageProps = {
+  initialData?: Exam[]
+}

--- a/src/features/exam/utils/types.ts
+++ b/src/features/exam/utils/types.ts
@@ -1,0 +1,19 @@
+export type Exam = {
+  id: number
+  title: string
+  subjectName: string
+  totalQuestions: number
+  submissionCount: number
+  createdAt: string
+  updatedAt: string
+  status: 'deployed' | 'pending'
+}
+
+export type Filters = {
+  course: string
+  subject: string
+}
+
+export type ExamPageProps = {
+  initialData?: Exam[]
+}

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,1 +1,2 @@
 export * from './examDropdown'
+export * from './mockExamList'

--- a/src/mocks/mockExamList.ts
+++ b/src/mocks/mockExamList.ts
@@ -1,0 +1,34 @@
+import type { Exam } from '../features/exam/utils/types'
+
+export const mockExamList: Exam[] = [
+  {
+    id: 1,
+    title: 'React & Redux 데일리 쪽지시험',
+    subjectName: 'React & Redux',
+    totalQuestions: 133,
+    submissionCount: 10,
+    createdAt: '2025.02.01 11:22:28',
+    updatedAt: '2025.02.28 11:22:28',
+    status: 'deployed',
+  },
+  {
+    id: 2,
+    title: 'TypeScript 기초 쪽지시험',
+    subjectName: 'TypeScript',
+    totalQuestions: 50,
+    submissionCount: 25,
+    createdAt: '2025.02.05 09:00:00',
+    updatedAt: '2025.02.20 14:30:00',
+    status: 'pending',
+  },
+  {
+    id: 3,
+    title: 'JavaScript 심화 쪽지시험',
+    subjectName: 'JavaScript',
+    totalQuestions: 80,
+    submissionCount: 15,
+    createdAt: '2025.02.10 10:00:00',
+    updatedAt: '2025.02.25 16:00:00',
+    status: 'deployed',
+  },
+]


### PR DESCRIPTION
쪽지시험 관리 페이지의 목록 화면 및 빈 화면을 구현했습니다.

## 📌 작업 내용

 [컴포넌트]
- ExamPage: 메인 페이지 (목록/빈 화면 분기 처리)
- FilterSection: 과정/과목 드롭다운 필터 + 검색 입력
- ExamList: DataTable 기반 시험 목록 테이블
- EmptyState: 데이터 없을 때 빈 화면

[설정 및 유틸]
- examConfig: 테이블 컬럼 정의 (배포 상태 버튼 포함)
- useSearchTerm: 검색어 상태 관리 커스텀 훅
- 타입 정의 (Exam, Filters, ExamPageProps)
- 배럴 패턴 적용

[테스트]
- mockExamList: 테스트용 시험 목록 데이터
- Storybook 스토리 추가 (Default, WithData, Empty)

## 🔗 관련 이슈

- closes #52 

## 📸 스크린샷 
<데이터 없을 때 빈 화면>
<img width="1601" height="555" alt="image" src="https://github.com/user-attachments/assets/34651482-cfcd-4d28-9f72-7ec5db351147" />

<시험 목록 테이블>
<img width="1706" height="412" alt="image" src="https://github.com/user-attachments/assets/70181d8f-7e3f-4082-bbd4-01c42384d6c3" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
