### PR TITLE
fix: 로그인 인증 유지 및 캐시 문제 수정

### DIFF
--- a/src/features/auth/hooks/useLogin.ts
+++ b/src/features/auth/hooks/useLogin.ts
@@ -4,17 +4,21 @@ import { login } from '@api/auth'
 import { showToast } from '@components'
 import { ROUTES_PATHS } from '@constants'
 import { useAuthStore } from '@stores'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 
 export function useLogin() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const setAccessToken = useAuthStore((state) => state.setAccessToken)
 
   return useMutation({
     mutationFn: (data: LoginRequest) => login(data),
     onSuccess: (data: LoginResponse) => {
+      queryClient.clear()
+
       setAccessToken(data.access_token)
+
       showToast('로그인성공', 'success')
       navigate(ROUTES_PATHS.MAIN)
     },


### PR DESCRIPTION
## 📌 작업 내용

- 로그인 성공 시 캐시 초기화 로직 추가: useMutation의 onSuccess 콜백 내에서 queryClient.clear()를 호출하여 이전 세션의 잔류 캐시 제거
- 인증 상태 동기화 개선: Zustand persist 미들웨어와 React Query 간의 상태 불일치 문제 해결
- 로그인 흐름 안정화: 토큰 갱신 후 메인 페이지 진입 시 데이터 무결성 보장

## 🔗 관련 이슈

- closes #148 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
