### PR TITLE
refactor: 응시내역 목록조회 페이지 api 연동 및 관련 코드 리팩토링

### DIFF
--- a/src/api/exams.ts
+++ b/src/api/exams.ts
@@ -1,4 +1,6 @@
 import type {
+  CohortsApiResponse,
+  CourseApiResponse,
   CreateExamModalPayload,
   DeploymentDetailResponse,
   DeploymentListParams,
@@ -6,6 +8,7 @@ import type {
   ExamDeployRequest,
   ExamListParams,
   ExamListResponse,
+  SubjectsApiResponse,
   SubmissionDetailResponse,
   SubmissionListParams,
   SubmissionListResponse,
@@ -193,7 +196,7 @@ export const deleteDeploymentRequest = async (deploymentId: number) => {
   return response.data
 }
 
-export const fetchCourseList = async () => {
+export const fetchCourseList = async (): Promise<CourseApiResponse> => {
   const response = await fetcher.get(ROUTES_PATHS_ADMIN.COURSE)
 
   return {
@@ -214,9 +217,8 @@ export const getSubmissionsRequest = async (
         page: params.page,
         size: params.size,
         search_keyword: params.searchKeyword,
-        subject_id: params.subjectId,
         cohort_id: params.cohortId,
-        generation_id: params.generationId,
+        exam_id: params.examId,
         sort: params.sort,
         order: params.order,
       },
@@ -226,10 +228,14 @@ export const getSubmissionsRequest = async (
   return response.data
 }
 
-export const fetchCohortsList = async (courseId: number) => {
+export const fetchCohortsList = async (
+  courseId: number
+): Promise<CohortsApiResponse> => {
   const response = await fetcher.get(ROUTES_PATHS_ADMIN.COHORTS({ courseId }))
 
-  return response.data
+  return {
+    cohortsList: response.data,
+  }
 }
 
 /**
@@ -258,7 +264,9 @@ export const deleteSubmissionRequest = async (submissionId: number) => {
 /*
  * 과목 리스트 API 요청
  */
-export const fetchSubjectsList = async (courseId: number) => {
+export const fetchSubjectsList = async (
+  courseId: number
+): Promise<SubjectsApiResponse> => {
   const response = await fetcher.get(ROUTES_PATHS_ADMIN.SUBJECTS({ courseId }))
 
   return {

--- a/src/components/common/modal/InfoSection.tsx
+++ b/src/components/common/modal/InfoSection.tsx
@@ -1,5 +1,5 @@
 import { TwoSplitInfo } from '@components'
-import { type DetailRow } from '@features/exams/deployments/components/deploymentHistoryModalConfig'
+import { type DetailRow } from '@features/exams/'
 
 type InfoSectionProps = {
   title: string

--- a/src/components/common/modal/TwoSplitInfo.tsx
+++ b/src/components/common/modal/TwoSplitInfo.tsx
@@ -5,7 +5,7 @@ import { inputVariant, type InputVariant } from '../input/inputStyle'
 
 type TwoSplitInfoProps = {
   label: string
-  value: string | number
+  value: string | number | undefined
   size: InputVariant['size']
   labelHeight?: number
   className?: string

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -14,7 +14,6 @@ export const ROUTES_PATHS = {
   }) => `${ROUTES_PATHS_ADMIN.QUESTIONS({ examId })}/${questionId}`,
   // 라우트용
   EXAM_QUESTIONS_ROUTE: `/exams/:examId/questions`,
-
   // 네비게이트용
   EXAM_QUESTIONS: ({ examId }: { examId: number }) =>
     `/exam/${examId}/questions`,
@@ -41,7 +40,7 @@ export const ROUTES_PATHS_ADMIN = {
     questionId: number
   }) => `/admin/exams/${examId}/questions/${questionId}`,
   COHORTS: ({ courseId }: { courseId: number }) =>
-    `/courses${courseId}/cohorts`,
+    `/courses/${courseId}/cohorts`,
   LOGIN: '/accounts/login',
   EXAM: '/admin/exams',
   COURSE: '/courses',

--- a/src/features/exams/deployments/components/deploymentHistoryModalConfig.tsx
+++ b/src/features/exams/deployments/components/deploymentHistoryModalConfig.tsx
@@ -2,7 +2,7 @@ import type { Distribution } from '@features/exams'
 
 export type DetailRow = {
   label: string
-  value: string | number
+  value: string | number | undefined
   isLink?: boolean
   isFullWidth?: boolean
 }

--- a/src/features/exams/index.ts
+++ b/src/features/exams/index.ts
@@ -54,7 +54,6 @@ export {
 } from './submissions/components/submissionDetailModalConfig.tsx'
 export { default as SubmissionDetailModal } from './submissions/components/SubmissionDetailModal.tsx'
 export { useSubmissionListQuery } from './queries/useSubmissionList.ts'
-// export { useSubmissionDetail } from './queries/useSubmissionDetail.ts'
 export { default as SubmissionDeletePopupModal } from './submissions/components/SubmissionDeletePopupModal.tsx'
 export type {
   SubmissionListResponse,
@@ -70,7 +69,6 @@ export * from './exam-managements/questions/schemas/questionValidationSchema.ts'
 export { useSaveAllQuestions } from '@features/exams/exam-managements/questions/queries/useQuestionMutation'
 export { default as SubmissionCheckModal } from './submissions/components/check-modal/SubmissionCheckModal.tsx'
 export { useSubmissionDetail } from './queries/useSubmissionDetail.ts'
-export * from './queries/useSubmissionDetail.ts'
 export { SubmissionCheckSide } from './submissions/components/check-modal/SubmissionCheckSide.tsx'
 export { SubmissionCheckBody } from './submissions/components/check-modal/SubmissionCheckBody.tsx'
 export { SubmissionCheckFooter } from './submissions/components/check-modal/SubmissionCheckFooter.tsx'

--- a/src/features/exams/queries/useCourseSubjectsListQuery.ts
+++ b/src/features/exams/queries/useCourseSubjectsListQuery.ts
@@ -1,8 +1,34 @@
+import type { Course, ModalMode, Subjects } from '@features/exams'
+
 import { fetchCourseList, fetchSubjectsList } from '@api'
 import { MOCK_COURSE_LIST, MOCK_SUBJECT_LIST } from '@mocks'
 import { useQuery } from '@tanstack/react-query'
 
-import type { ModalMode } from '../types'
+const normalizeSubject = (raw: {
+  id: number
+  course_id: number
+  title: string
+  status: string
+  thumbnail_img_url: string
+}): Subjects => ({
+  id: raw.id,
+  courseId: raw.course_id,
+  title: raw.title,
+  status: raw.status,
+  thumbnailImgUrl: raw.thumbnail_img_url,
+})
+
+export const normalizeCourse = (raw: {
+  id: number
+  name: string
+  tag: string
+  thumbnail_img_url: string
+}): Course => ({
+  id: raw.id,
+  name: raw.name,
+  tag: raw.tag,
+  thumbnailImgUrl: raw.thumbnail_img_url,
+})
 
 export const useCourseSubjectsList = ({ mode }: { mode: ModalMode }) =>
   useQuery({
@@ -10,7 +36,9 @@ export const useCourseSubjectsList = ({ mode }: { mode: ModalMode }) =>
     enabled: mode === 'create',
     queryFn: () => fetchCourseList(),
     initialData:
-      mode === 'update' ? { courseList: MOCK_COURSE_LIST } : undefined,
+      mode === 'update'
+        ? { courseList: MOCK_COURSE_LIST.map(normalizeCourse) }
+        : undefined,
     staleTime: Infinity,
     retry: false,
   })
@@ -28,7 +56,7 @@ export const useSubjectsList = (
         ? {
             subjectsList: MOCK_SUBJECT_LIST.filter(
               (s) => s.course_id === courseId
-            ),
+            ).map(normalizeSubject),
           }
         : undefined,
     staleTime: Infinity,

--- a/src/features/exams/queries/useSubmissionDeleteMutation.ts
+++ b/src/features/exams/queries/useSubmissionDeleteMutation.ts
@@ -1,6 +1,6 @@
 import { deleteSubmissionRequest } from '@api/exams'
+import { showToast } from '@components'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'react-hot-toast'
 
 export const useDeleteSubmissionMutationQuery = (
   onSuccessCallback: () => void
@@ -12,10 +12,12 @@ export const useDeleteSubmissionMutationQuery = (
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['submissions', 'list'] })
 
+      showToast('응시 내역이 삭제되었습니다.', 'success')
+
       onSuccessCallback()
     },
     onError: () => {
-      toast.error('삭제에 실패했습니다. 다시 시도해주세요.')
+      showToast('응시 내역 삭제에 실패했습니다. 다시 시도해주세요.', 'fail')
     },
   })
 }

--- a/src/features/exams/queries/useSubmissionDetail.ts
+++ b/src/features/exams/queries/useSubmissionDetail.ts
@@ -1,6 +1,5 @@
 import { getSubmissionDetailRequest } from '@api/exams'
 import { useQuery } from '@tanstack/react-query'
-// import { MOCK_SUBMISSION_DETAIL } from '@mocks/mockSubmissionData'
 
 /**
  * 응시 내역 상세(풀이 보기) 조회 커스텀 훅
@@ -11,7 +10,6 @@ export const useSubmissionDetail = (submissionId: number | null) =>
   useQuery({
     queryKey: ['submissions', 'detail', submissionId],
     queryFn: () => getSubmissionDetailRequest(submissionId as number),
-    // queryFn: () => Promise.resolve(MOCK_SUBMISSION_DETAIL),
     enabled: !!submissionId,
-    staleTime: 1000 * 60 * 5, // 5분 의도함
+    staleTime: 1000 * 60 * 5,
   })

--- a/src/features/exams/queries/useSubmissionList.ts
+++ b/src/features/exams/queries/useSubmissionList.ts
@@ -1,6 +1,5 @@
 import { getSubmissionsRequest } from '@api/exams'
 import { useQuery } from '@tanstack/react-query'
-// import { MOCK_SUBMISSION_LIST } from '@mocks/mockSubmissionData'
 
 import type {
   Submission,
@@ -16,7 +15,6 @@ export const useSubmissionListQuery = (params: SubmissionListParams) =>
   useQuery({
     queryKey: ['submissions', 'list', params],
     queryFn: () => getSubmissionsRequest(params),
-    // queryFn: () => Promise.resolve(MOCK_SUBMISSION_LIST),
     select: (data: SubmissionListResponse) => ({
       totalCount: data.totalCount,
       submissions: data.submissions.map(
@@ -28,7 +26,7 @@ export const useSubmissionListQuery = (params: SubmissionListParams) =>
           userName: item.name,
           generation: item.generationNumber,
           endedAt: item.finishedAt,
-
+          cohortId: item.cohortId,
           correctCount: 0,
           totalCount: 0,
           spentTime: '',

--- a/src/features/exams/shared/components/ExamDeploymentsModal.tsx
+++ b/src/features/exams/shared/components/ExamDeploymentsModal.tsx
@@ -72,14 +72,13 @@ export default function ExamDeploymentsModal({
   }
 
   const { data: courseRes } = useCourseList()
-
   const { data: cohortRes } = useCohortsList(Number(values.courseId))
 
   const FIELDS = createInputFields({
     values,
     updateValue,
-    courseList: courseRes?.courseList.data ?? [],
-    cohortList: cohortRes?.data ?? [],
+    courseList: courseRes?.courseList ?? [],
+    cohortList: cohortRes?.cohortsList ?? [],
   })
 
   return (

--- a/src/features/exams/shared/components/detail-modal/ExamQuestionDetailBody.tsx
+++ b/src/features/exams/shared/components/detail-modal/ExamQuestionDetailBody.tsx
@@ -26,6 +26,18 @@ export function ExamQuestionDetailBody({
   onPrev,
   onNext,
 }: ExamQuestionDetailBodyProps) {
+  const totalQuestions = exam.questions.length
+  const hasValidIndex =
+    totalQuestions > 0 && currentIndex >= 0 && currentIndex < totalQuestions
+
+  if (!hasValidIndex) {
+    return (
+      <div className="flex h-full items-center justify-center text-neutral-400">
+        표시할 문제가 없습니다.
+      </div>
+    )
+  }
+
   const question = exam.questions[currentIndex]
 
   const typeLabel =

--- a/src/features/exams/shared/hooks/useExamForm.ts
+++ b/src/features/exams/shared/hooks/useExamForm.ts
@@ -46,6 +46,7 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
   })
 
   const [logoFile, setLogoFile] = useState<File | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
 
   const updateValue = (
     key: keyof typeof values,
@@ -55,11 +56,15 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
       if (value instanceof File) {
         setLogoFile(value)
 
+        const objectUrl = URL.createObjectURL(value)
+
+        setPreviewUrl(objectUrl)
         setValues((prev) => ({
           ...prev,
-          thumbnailImg: URL.createObjectURL(value),
+          thumbnailImg: objectUrl,
         }))
       } else {
+        setPreviewUrl(null)
         setValues((prev) => ({ ...prev, thumbnailImg: value as string }))
       }
 
@@ -89,6 +94,15 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
       }))
     }
   }, [modalMode, examDetail])
+
+  useEffect(
+    () => () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+    },
+    [previewUrl]
+  )
 
   const examCreateMutation = useExamCreateMutation(onClose)
   const examUpdateMutation = useExamUpdateMutation(onClose)
@@ -148,6 +162,7 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
       thumbnailImg: '',
     })
     setLogoFile(null)
+    setPreviewUrl(null)
     onClose()
   }
 

--- a/src/features/exams/submissions/components/SubmissionDetailModal.stories.tsx
+++ b/src/features/exams/submissions/components/SubmissionDetailModal.stories.tsx
@@ -1,0 +1,93 @@
+/**
+ * SubmissionDetailModal Storybook
+ * - 응시 상세 모달 UI 테스트용 스토리북 코드
+ * - QueryClientProvider 적용
+ * - Strict TypeScript + any 금지
+ */
+
+import type { Submission } from '@features/exams'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import SubmissionDetailModal from './SubmissionDetailModal'
+
+/**
+ * Submission 상세 정보 Mock 데이터
+ * - 실제 Submission 타입을 정확히 반영하여 구성
+ */
+const mockSubmission: Submission = {
+  id: 101,
+  submissionId: 101,
+  title: 'React 중간평가',
+  examTitle: 'React 중간평가',
+  subjectName: 'React',
+  nickname: 'jerry12',
+  userName: '김철수',
+  courseName: '프론트엔드',
+  generation: 5,
+  generationNumber: 5,
+  cheatingCount: 0,
+  score: 85,
+
+  /** 선택적 필드 (rows에서 필요할 수 있음) */
+  correctCount: 17,
+  totalCount: 20,
+  timeLimit: 30,
+  openedAt: '2025-01-10 14:00:00',
+  closedAt: '2025-01-10 14:30:00',
+  spentTime: '25분',
+
+  /** 필수 날짜 정보 */
+  startedAt: '2025-01-10 14:00:00',
+  endedAt: '2025-01-10 14:25:00',
+
+  /** 선택값 (필요 시 InfoSection 사용) */
+  cohortId: 3,
+}
+
+/** React Query Provider */
+const queryClient = new QueryClient()
+
+const meta: Meta<typeof SubmissionDetailModal> = {
+  title: 'Modals/SubmissionDetailModal',
+  component: SubmissionDetailModal,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof SubmissionDetailModal>
+
+/**
+ * 기본 렌더 스토리
+ */
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState<boolean>(true)
+
+    return (
+      <div className="h-screen bg-neutral-100 p-10">
+        <button
+          onClick={() => setIsOpen(true)}
+          className="rounded bg-primary-500 px-4 py-2 text-white"
+        >
+          모달 열기
+        </button>
+
+        <SubmissionDetailModal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          data={mockSubmission}
+        />
+      </div>
+    )
+  },
+}

--- a/src/features/exams/submissions/components/check-modal/SubmissionCheckModal.stories.tsx
+++ b/src/features/exams/submissions/components/check-modal/SubmissionCheckModal.stories.tsx
@@ -1,0 +1,148 @@
+/**
+ * SubmissionCheckModal Storybook
+ * - 응시 정답/풀이 확인 모달 UI 테스트용 스토리
+ * - React Query + MSW를 사용해 상세 응답을 Mock 처리
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { useState } from 'react'
+
+import SubmissionCheckModal from './SubmissionCheckModal'
+
+/**
+ * Mock 응시 상세 응답 데이터
+ * - useSubmissionDetail 훅에서 convertToCamelCase 등을 통해 camelCase로 변환되어 들어간다고 가정
+ */
+const mockSubmissionDetail = {
+  exam: {
+    examTitle: 'React 중간평가',
+    subjectName: 'React 프로그래밍',
+    durationTime: 30,
+    openAt: '2025-01-10T14:00:00',
+    closeAt: '2025-01-10T14:30:00',
+  },
+  student: {
+    nickname: 'jerry12',
+    name: '김철수',
+    course_name: '프론트엔드 개발 부트캠프',
+    cohort_number: 5,
+  },
+  result: {
+    score: 85,
+    correctAnswerCount: 17,
+    totalQuestionCount: 20,
+    cheatingCount: 0,
+    elapsedTime: 1500,
+  },
+  questions: [
+    {
+      questionId: 1,
+      number: 1,
+      type: 'multiple_choice',
+      question: '다음 중 React의 특징이 아닌 것은?',
+      prompt: 'React의 특성에 대한 보기 중 옳지 않은 것을 고르시오.',
+      options: [
+        '선언적 UI',
+        '컴포넌트 기반',
+        '양방향 데이터 바인딩',
+        'Virtual DOM 사용',
+      ],
+      point: 5,
+      submittedAnswer: '양방향 데이터 바인딩',
+      correctAnswer: '양방향 데이터 바인딩',
+      isCorrect: true,
+      explanation:
+        'React는 단방향 데이터 흐름을 기본으로 하며, 양방향 데이터 바인딩은 Angular의 주요 특징입니다.',
+    },
+    {
+      questionId: 2,
+      number: 2,
+      type: 'ox',
+      question:
+        'React의 useEffect 훅은 렌더링 직후와 의존성 배열이 변경될 때 실행된다.',
+      prompt: '',
+      options: ['O', 'X'],
+      point: 5,
+      submittedAnswer: 'O',
+      correctAnswer: 'O',
+      isCorrect: true,
+      explanation:
+        'useEffect는 기본적으로 첫 렌더 후와, 의존성 배열에 있는 값이 변경될 때마다 실행됩니다.',
+    },
+  ],
+}
+
+/**
+ * React Query Client
+ */
+const queryClient = new QueryClient()
+
+const meta: Meta<typeof SubmissionCheckModal> = {
+  title: 'Modals/SubmissionCheckModal',
+  component: SubmissionCheckModal,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        /**
+         * 응시 상세 조회 API Mock
+         * - 실제 프로젝트의 ROUTES_PATHS_ADMIN.EXAM_SUBMISSION_ID({ submissionId })와 URL이 동일해야 한다.
+         * - 필요 시 이 URL을 실제 경로에 맞게 수정해 사용하면 된다.
+         */
+        http.get(
+          'https://api.ozcodingschool.site/api/v1/admin/exams/submissions/:submissionId',
+          ({ params }) => {
+            const { submissionId } = params
+
+            if (submissionId === '101') {
+              return HttpResponse.json(mockSubmissionDetail)
+            }
+
+            return HttpResponse.json(mockSubmissionDetail)
+          }
+        ),
+      ],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof SubmissionCheckModal>
+
+/**
+ * 기본 스토리
+ * - submissionId=101, 모달 오픈 상태에서 시작
+ */
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState<boolean>(true)
+
+    return (
+      <div className="h-screen bg-neutral-100 p-10">
+        <button
+          type="button"
+          className="mb-4 rounded bg-primary-500 px-4 py-2 text-white"
+          onClick={() => setIsOpen(true)}
+        >
+          풀이 보기 모달 열기
+        </button>
+
+        <SubmissionCheckModal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          submissionId={101}
+        />
+      </div>
+    )
+  },
+}

--- a/src/features/exams/submissions/components/submissionDetailModalConfig.tsx
+++ b/src/features/exams/submissions/components/submissionDetailModalConfig.tsx
@@ -2,7 +2,7 @@ import type { Submission } from '@features/exams'
 
 export type DetailRow = {
   label: string
-  value: string | number
+  value: string | number | undefined
   isLink?: boolean
   isFullWidth?: boolean
   subValue?: string | number

--- a/src/features/exams/types.ts
+++ b/src/features/exams/types.ts
@@ -60,6 +60,7 @@ export type Submission = {
   startedAt: string
   endedAt: string
   spentTime: string
+  cohortId: number
 }
 
 export type Distribution = {
@@ -177,11 +178,19 @@ export type ExamDeploymentsPayload = {
   closeAt: string
 }
 
+export type CourseApiResponse = {
+  courseList: Course[]
+}
+
 export type Course = {
   id: number
   name: string
   tag: string
   thumbnailImgUrl: string
+}
+
+export type CohortsApiResponse = {
+  cohortsList: Cohorts[]
 }
 
 export type Cohorts = {
@@ -196,9 +205,11 @@ export type SubmissionListParams = {
   searchKeyword?: string
   subjectId?: string
   cohortId?: string
-  generationId?: string
+  courseId?: string
+  // generationId?: string
   sort?: string
   order?: 'asc' | 'desc'
+  examId?: string
 }
 
 export type SubmissionApiItem = {
@@ -213,6 +224,7 @@ export type SubmissionApiItem = {
   cheatingCount: number
   startedAt: string
   finishedAt: string
+  cohortId: number
 }
 
 export type SubmissionListResponse = {
@@ -265,6 +277,10 @@ export type SubmissionDetailResponse = {
     isCorrect: boolean
     explanation: string
   }>
+}
+
+export type SubjectsApiResponse = {
+  subjectsList: Subjects[]
 }
 
 export type Subjects = {

--- a/src/mocks/examFormMockData.ts
+++ b/src/mocks/examFormMockData.ts
@@ -19,7 +19,8 @@ export const MOCK_SUBJECT_LIST = [
     course_id: 1,
     title: 'Python',
     status: 'active',
-    thumbnail_img_url: '',
+    thumbnail_img_url:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/2048px-Python-logo-notext.svg.png',
   },
   {
     id: 4,
@@ -34,5 +35,29 @@ export const MOCK_SUBJECT_LIST = [
     title: 'Typescript',
     status: 'active',
     thumbnail_img_url: '',
+  },
+  {
+    id: 9,
+    course_id: 1,
+    title: 'Django',
+    status: 'active',
+    thumbnail_img_url:
+      'https://storage.educast.com/image/9a0ecd1f-ebf5-4e99-98e4-5edfe7949075/1000.jpg',
+  },
+  {
+    id: 10,
+    course_id: 1,
+    title: 'JavaScript',
+    status: 'active',
+    thumbnail_img_url:
+      'https://velog.velcdn.com/images/cocowonji/post/e8f90515-cce9-4e57-996b-a4470cae97ac/image.png',
+  },
+  {
+    id: 11,
+    course_id: 1,
+    title: 'faseAPI',
+    status: 'active',
+    thumbnail_img_url:
+      'https://images.seeklogo.com/logo-png/49/1/fastapi-logo-png_seeklogo-499530.png',
   },
 ] as const

--- a/src/mocks/mockSubmissionData.ts
+++ b/src/mocks/mockSubmissionData.ts
@@ -21,6 +21,7 @@ export const MOCK_SUBMISSION_LIST: SubmissionListResponse = {
       cheatingCount: 0,
       startedAt: '2026-01-02 10:00:00',
       finishedAt: '2026-01-02 11:00:00',
+      cohortId: 14,
     },
   ],
 }

--- a/src/pages/SubmissionManagementPage.stories.tsx
+++ b/src/pages/SubmissionManagementPage.stories.tsx
@@ -1,0 +1,170 @@
+import type { Course } from '@features/exams'
+import type { Subjects } from '@features/exams'
+import type { Cohorts } from '@features/exams'
+import type { SubmissionListResponse } from '@features/exams'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { API_BASE_URL } from '@constants'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+
+import SubmissionManagementPage from './SubmissionManagementPage'
+
+/**
+ * Mock Course Data
+ */
+const mockCourses: Course[] = [
+  {
+    id: 1,
+    name: '프론트엔드',
+    tag: 'FE',
+    thumbnailImgUrl: 'https://placehold.co/100x60',
+  },
+  {
+    id: 2,
+    name: '백엔드',
+    tag: 'BE',
+    thumbnailImgUrl: 'https://placehold.co/100x60',
+  },
+]
+
+/**
+ * Mock Subjects
+ */
+const mockSubjects: Subjects[] = [
+  {
+    id: 11,
+    courseId: 1,
+    title: 'React',
+    status: 'active',
+    thumbnailImgUrl: 'https://placehold.co/80x50',
+  },
+  {
+    id: 12,
+    courseId: 1,
+    title: 'TypeScript',
+    status: 'active',
+    thumbnailImgUrl: 'https://placehold.co/80x50',
+  },
+]
+
+/**
+ * Mock Cohorts
+ */
+const mockCohorts: Cohorts[] = [
+  {
+    id: 101,
+    courseId: 1,
+    number: 1,
+    status: 'active',
+  },
+  {
+    id: 102,
+    courseId: 1,
+    number: 2,
+    status: 'active',
+  },
+]
+
+/**
+ * Mock Submission List Response
+ */
+const mockSubmissionList: SubmissionListResponse = {
+  page: 1,
+  size: 10,
+  totalCount: 2,
+  submissions: [
+    {
+      submissionId: 900,
+      nickname: 'jerry12',
+      name: '김철수',
+      courseName: '프론트엔드',
+      generationNumber: 1,
+      examTitle: 'React 중간평가',
+      subjectName: 'React',
+      score: 85,
+      cheatingCount: 0,
+      startedAt: '2025-01-12 14:00:00',
+      finishedAt: '2025-01-12 14:25:00',
+      cohortId: 14,
+    },
+    {
+      submissionId: 901,
+      nickname: 'sunny',
+      name: '박영희',
+      courseName: '프론트엔드',
+      generationNumber: 2,
+      examTitle: 'TS 기초 평가',
+      subjectName: 'TypeScript',
+      score: 92,
+      cheatingCount: 0,
+      startedAt: '2025-01-10 10:00:00',
+      finishedAt: '2025-01-10 10:20:00',
+      cohortId: 14,
+    },
+  ],
+}
+
+/**
+ * React Query Client Instance
+ */
+const queryClient = new QueryClient()
+
+const meta: Meta<typeof SubmissionManagementPage> = {
+  title: 'Pages/SubmissionManagementPage',
+  component: SubmissionManagementPage,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(`${API_BASE_URL}/course`, () =>
+          HttpResponse.json({
+            courseList: mockCourses,
+          })
+        ),
+        http.get(`${API_BASE_URL}/courses/:courseId/cohorts`, ({ params }) => {
+          const { courseId } = params
+
+          HttpResponse.json({
+            cohortsList: mockCohorts.filter(
+              (s) => s.courseId === Number(courseId)
+            ),
+          })
+        }),
+
+        http.get(`${API_BASE_URL}/courses/:courseId/subjects`, ({ params }) => {
+          const { courseId } = params
+
+          return HttpResponse.json({
+            subjectsList: mockSubjects.filter(
+              (s) => s.courseId === Number(courseId)
+            ),
+          })
+        }),
+        /**
+         * Submission List API Mock
+         */
+        http.get('/api/v1/admin/exams/submissions', () =>
+          HttpResponse.json(mockSubmissionList)
+        ),
+      ],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof SubmissionManagementPage>
+
+/**
+ * 기본 스토리: 전체 응시 내역 페이지 흐름 테스트
+ */
+export const Default: Story = {
+  render: () => <SubmissionManagementPage />,
+}

--- a/src/pages/SubmissionManagementPage.tsx
+++ b/src/pages/SubmissionManagementPage.tsx
@@ -1,67 +1,85 @@
-import { type DropdownConfig, FilterSection } from '@components'
+import {
+  type DropdownConfig,
+  type DropdownItem,
+  FilterSection,
+} from '@components'
 import { PAGE_SIZE } from '@constants'
 import {
   type Submission,
   SubmissionDetailModal,
   SubmissionList,
+  useCohortsList,
+  useCourseList,
+  useSubjectsList,
   useSubmissionListQuery,
 } from '@features/exams'
-import {
-  COURSE_LIST_DROPDOWN,
-  GENERATION_LIST_DROPDOWN,
-  SUBJECT_LIST_DROPDOWN,
-} from '@mocks'
 import { useState } from 'react'
 import { useSearchParams } from 'react-router'
 
-const SUBMISSION_DROPDOWNS: DropdownConfig[] = [
-  { key: 'course', items: COURSE_LIST_DROPDOWN, placeholder: '과정' },
-  { key: 'subject', items: SUBJECT_LIST_DROPDOWN, placeholder: '과목' },
-  { key: 'generation', items: GENERATION_LIST_DROPDOWN, placeholder: '기수' },
-]
+export type SubmissionDropdownOption = {
+  id: string | number
+  name?: string
+  title?: string
+  number?: number
+}
+
+const toDropdownItems = <T extends SubmissionDropdownOption>(
+  list: T[],
+  getLabel: (item: T) => string
+): DropdownItem[] =>
+  list.map((item) => ({
+    label: getLabel(item),
+    value: String(item.id),
+  }))
 
 export default function SubmissionManagementPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [selectedItem, setSelectedItem] = useState<Submission | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [filters, setFilters] = useState({
+    course: '',
+    subject: '',
+    cohort: '',
+    searchKeyword: '',
+  })
 
   const page = searchParams.get('page') || '1'
-  const course = searchParams.get('course') || ''
-  const subject = searchParams.get('subject') || ''
-  const generation = searchParams.get('generation') || ''
-  const search = searchParams.get('search') || ''
+  const examId = searchParams.get('exam_id') || ''
 
   const { data, isLoading } = useSubmissionListQuery({
     page: Number(page),
     size: PAGE_SIZE,
-    searchKeyword: search || undefined,
-    subjectId: subject || undefined,
-    cohortId: course || undefined,
-    generationId: generation || undefined,
+    searchKeyword: filters.searchKeyword || undefined,
+    cohortId: filters.cohort || undefined,
+    examId: examId || undefined,
   })
 
-  const updateParams = (newParams: Record<string, string>) => {
-    const current = Object.fromEntries(searchParams.entries())
-    const updatedParams = { ...current, ...newParams }
-
-    Object.keys(updatedParams).forEach((key) => {
-      if (!updatedParams[key]) {
-        delete updatedParams[key]
-      }
-    })
-    setSearchParams(updatedParams)
-  }
-
   const handleChangeFilters = (key: string, value: string) => {
-    updateParams({ [key]: value, page: '1' })
+    if (key === 'course') {
+      setFilters((prev) => ({
+        ...prev,
+        course: value,
+        subject: '',
+        generation: '',
+      }))
+    } else {
+      setFilters((prev) => ({ ...prev, [key]: value }))
+    }
+
+    setSearchParams({ page: '1' })
   }
 
   const handleChangeSearch = (value: string) => {
-    updateParams({ search: value })
+    setFilters((prev) => ({ ...prev, searchKeyword: value }))
   }
 
   const handleSearch = () => {
-    updateParams({ page: '1' })
+    setSearchParams({
+      page: '1',
+      size: '10',
+      search_keyword: filters.searchKeyword,
+      cohort_id: filters.cohort,
+    })
   }
 
   const handleRowClick = (data: Submission) => {
@@ -70,6 +88,36 @@ export default function SubmissionManagementPage() {
       setIsModalOpen(true)
     }
   }
+
+  const { data: courseRes } = useCourseList()
+  const courseList = courseRes?.courseList ?? []
+  const selectedCourseId = filters.course ? Number(filters.course) : undefined
+
+  const { data: subjectsRes } = useSubjectsList(selectedCourseId ?? 0, {
+    mode: 'update',
+  })
+  const { data: cohortRes } = useCohortsList(selectedCourseId ?? 0)
+
+  const subjectsList = subjectsRes?.subjectsList ?? []
+  const cohortsList = cohortRes?.cohortsList ?? []
+
+  const submissionApiDropdowns: DropdownConfig[] = [
+    {
+      key: 'course',
+      items: toDropdownItems(courseList, (item) => `${item.name}`),
+      placeholder: '과정',
+    },
+    {
+      key: 'subject',
+      items: toDropdownItems(subjectsList, (item) => `${item.title}`),
+      placeholder: '과목',
+    },
+    {
+      key: 'cohort',
+      items: toDropdownItems(cohortsList, (item) => `${item.number}기`),
+      placeholder: '기수',
+    },
+  ]
 
   return (
     <section className="px-15 py-11">
@@ -80,27 +128,27 @@ export default function SubmissionManagementPage() {
 
         <div className="mb-3">
           <FilterSection
-            dropdowns={SUBMISSION_DROPDOWNS}
-            selectedValues={{ course, subject, generation }}
+            dropdowns={submissionApiDropdowns}
+            selectedValues={filters}
             onChangeFilters={handleChangeFilters}
-            search={search}
+            search={filters.searchKeyword}
             onChangeSearch={handleChangeSearch}
             onSubmit={handleSearch}
           />
         </div>
-
         <div>
           <SubmissionList
             data={data?.submissions ?? []}
             pageCount={data ? Math.ceil(data.totalCount / PAGE_SIZE) : 0}
             pageIndex={Number(page) - 1}
-            onPageChange={(index) => updateParams({ page: String(index + 1) })}
+            onPageChange={(index) =>
+              setSearchParams({ page: String(index + 1) })
+            }
             onRowClick={handleRowClick}
             isLoading={isLoading}
           />
         </div>
       </div>
-
       <SubmissionDetailModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}


### PR DESCRIPTION
## 📌 작업 내용

- 응시내역 상세조회 모달, 풀이보기 모달의 API 연동 코드 확인
- 
- 응시내역 관리 필터를 mock 데이터 기반에서 API 기반으로 전환
   - 과정 / 과목 / 기수 드롭다운을 실제 API 응답으로 구성
   - 
- 응시내역 필터 상태 관리 구조 리팩토링
   - URL 파라미터와 필터 상태 분리
   - 과정 변경 시 하위 필터(과목, 기수) 초기화
   - 검색 버튼 클릭 시에만 필터 조건 적용
   - 
- 드롭다운 렌더링 오류 수정
  - undefined key로 인한 React 경고 해결
  - 기수(cohort) 드롭다운 value 매핑 방식 개선
  - 
- React Query 연동 구조 개선
  - queryFn과 initialData 반환 타입 일치화
  - 응시내역 삭제 시 목록 쿼리 invalidate 처리
  - 불필요한 네트워크 요청 방지

- Storybook 환경 안정화
  - QueryClientProvider 및 Router 컨텍스트 추가
  - MSW를 이용한 응시내역/상세 조회 API Mock 구성
  - 실제 API 요청으로 빠져 CORS 오류 발생하던 문제 해결
  - mock 데이터 camelCase 적용으로 런타임 오류 수정

- Storybook 렌더링 오류 수정
  - 중첩 Router 렌더링 문제 해결
  - subjectName undefined로 인한 slice 에러 수정

## 🔗 관련 이슈

- closes #153 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
