### PR TITLE
refactor: 쪽지시험 목록조회 필터링 api 연동

### DIFF
--- a/src/features/exams/queries/useDeploymentListQuery.ts
+++ b/src/features/exams/queries/useDeploymentListQuery.ts
@@ -9,11 +9,18 @@ import { useQuery } from '@tanstack/react-query'
 
 export const useDeploymentListQuery = (params: DeploymentListParams) =>
   useQuery({
-    queryKey: ['deployments', 'list', params],
+    queryKey: [
+      'deployments',
+      params.page,
+      params.size,
+      params.searchKeyword,
+      params.subjectId,
+      params.cohortId,
+    ],
     queryFn: () => getDeploymentsRequest(params),
     select: (data: DeploymentListResponse) => ({
       ...data,
-      deployments: data.deployments.map(
+      deployments: data.results.map(
         (d): Distribution => ({
           deploymentId: d.deploymentId,
           examTitle: d.examTitle,

--- a/src/features/exams/shared/components/ExamDeploymentsModal.tsx
+++ b/src/features/exams/shared/components/ExamDeploymentsModal.tsx
@@ -60,14 +60,16 @@ export default function ExamDeploymentsModal({
 
       return
     }
+    const toISO = (value: string) => new Date(value).toISOString()
+
     const parsed = schemaResult.data
 
     createExamDeploymentsRequest({
       examId: parsed.examId,
       cohortId: parsed.cohortId,
       durationTime: parsed.durationTime,
-      openAt: parsed.openAt,
-      closeAt: parsed.closeAt,
+      openAt: toISO(parsed.openAt),
+      closeAt: toISO(parsed.closeAt),
     })
   }
 

--- a/src/features/exams/shared/components/examConfig.tsx
+++ b/src/features/exams/shared/components/examConfig.tsx
@@ -31,11 +31,11 @@ export const ExamColumns = (
     cell: ({ row }) => row.index + 1,
   },
   {
-    accessorKey: 'questionCount',
+    accessorKey: 'totalQuestions',
     header: '총 문제 수',
   },
   {
-    accessorKey: 'submitCount',
+    accessorKey: 'submissionCount',
     header: '응시 수',
   },
   {

--- a/src/features/exams/types.ts
+++ b/src/features/exams/types.ts
@@ -26,11 +26,12 @@ export type ExamListResponse = {
   size: number
   total_count: number
   exams: ExamApiItem[]
+  results: ExamApiItem[]
 }
 
 export type ExamApiItem = {
-  exam_id: number
-  exam_title: string
+  id: number
+  title: string
   subject_name: string
   question_count: number
   submit_count: number
@@ -123,6 +124,17 @@ export type DeploymentListResponse = {
   size: number
   totalCount: number
   deployments: Array<{
+    deploymentId: number
+    examTitle: string
+    subjectName: string
+    cohortNumber: number
+    courseName: string
+    submitCount: number
+    averageScore: number
+    status: string
+    createdAt: string
+  }>
+  results: Array<{
     deploymentId: number
     examTitle: string
     subjectName: string

--- a/src/features/exams/utils/transformExam.ts
+++ b/src/features/exams/utils/transformExam.ts
@@ -1,8 +1,8 @@
 import type { Exam, ExamApiItem } from '../types'
 
 export const transformExam = (item: ExamApiItem): Exam => ({
-  id: item.exam_id,
-  title: item.exam_title,
+  id: item.id,
+  title: item.title,
   subjectName: item.subject_name,
   totalQuestions: item.question_count,
   submissionCount: item.submit_count,

--- a/src/pages/ExamManagementPage.tsx
+++ b/src/pages/ExamManagementPage.tsx
@@ -1,5 +1,5 @@
 import { FilterSection } from '@components'
-import { EXAM_DROPDOWNS, PAGE_SIZE } from '@constants'
+import { PAGE_SIZE } from '@constants'
 import {
   EmptyState,
   type Exam,
@@ -11,41 +11,32 @@ import {
   useExamListQuery,
 } from '@features/exams'
 import { useModal } from '@hooks/useModal'
-import { useSearchParams } from 'react-router'
+import { useCourseSubjectCohortDropdowns, useUrlFilters } from '@pages'
+import { useState } from 'react'
 
 /**
  * 쪽지시험 관리 페이지
  * - useSearchParams로 URL 상태 관리 및 useExamListQuery로 서버 데이터 페칭
  */
 export default function ExamManagementPage() {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [course, setCourse] = useState<string>('')
+  const { dropdowns: examDropdowns } = useCourseSubjectCohortDropdowns({
+    course,
+  })
 
-  const page = searchParams.get('page') || '1'
-  const course = searchParams.get('course') || ''
-  const subject = searchParams.get('subject') || ''
-  const search = searchParams.get('search') || ''
-
-  const updateParams = (newParams: Record<string, string>) => {
-    const current = Object.fromEntries(searchParams.entries())
-    const updated = { ...current, ...newParams }
-
-    Object.keys(updated).forEach((key) => {
-      if (!updated[key]) delete updated[key]
-    })
-
-    setSearchParams(updated)
-  }
+  const { page, filters, setFilters, updateSearchParams, changePage } =
+    useUrlFilters()
 
   // 서버 데이터 fetch
   const { data, isLoading } = useExamListQuery({
     page: Number(page),
     size: PAGE_SIZE,
-    searchKeyword: search || undefined,
-    subjectId: subject ? Number(subject) : undefined,
+    searchKeyword: filters.searchKeyword || undefined,
+    subjectId: filters.subjectId ? Number(filters.subjectId) : undefined,
   })
 
   // 데이터 변환
-  const exams: Exam[] = data?.exams?.map(transformExam) ?? []
+  const exams: Exam[] = data?.results.map(transformExam) ?? []
   const totalCount = data?.total_count ?? 0
   const pageCount = Math.ceil(totalCount / PAGE_SIZE)
 
@@ -56,15 +47,31 @@ export default function ExamManagementPage() {
   const updateModal = useModal<Exam>()
 
   const handleChangeFilters = (key: string, value: string) => {
-    updateParams({ [key]: value, page: '1' })
+    if (key === 'course') {
+      setCourse(value)
+      setFilters((prev) => ({
+        ...prev,
+        subjectId: '',
+        cohortId: '',
+      }))
+    } else {
+      setFilters((prev) => ({
+        ...prev,
+        [key]: value,
+      }))
+    }
   }
 
   const handleChangeSearch = (value: string) => {
-    updateParams({ search: value })
+    setFilters((prev) => ({ ...prev, searchKeyword: value }))
   }
 
   const handleSearch = () => {
-    updateParams({ page: '1' })
+    updateSearchParams({
+      searchKeyword: filters.searchKeyword,
+      subjectId: filters.subjectId,
+      cohortId: filters.cohortId,
+    })
   }
 
   const renderExamList = () => {
@@ -82,7 +89,7 @@ export default function ExamManagementPage() {
         data={exams}
         pageCount={pageCount}
         pageIndex={Number(page) - 1}
-        onPageChange={(index) => updateParams({ page: String(index + 1) })}
+        onPageChange={(index) => changePage(index + 1)}
         onButtonClick={createModal.modalOpen}
         onExamUpdateClick={updateModal.modalOpen}
         onDetailClick={detailModal.modalOpen}
@@ -100,10 +107,10 @@ export default function ExamManagementPage() {
 
         <div className="mb-3">
           <FilterSection
-            dropdowns={EXAM_DROPDOWNS}
-            selectedValues={{ course, subject }}
+            dropdowns={examDropdowns}
+            selectedValues={{ course, ...filters }}
             onChangeFilters={handleChangeFilters}
-            search={search}
+            search={filters.searchKeyword}
             onChangeSearch={handleChangeSearch}
             onSubmit={handleSearch}
           />

--- a/src/pages/SubmissionManagementPage.tsx
+++ b/src/pages/SubmissionManagementPage.tsx
@@ -73,6 +73,7 @@ export default function SubmissionManagementPage() {
     updateSearchParams({
       searchKeyword: filters.searchKeyword,
       cohortId: filters.cohortId,
+      subjectId: filters.subjectId,
     })
   }
 


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 필터링 드롭다운 api 연동
- 목록 리스트 조회 완료
- 쪽지시험 목록 리스트 타입 및 accessorkey 값 수정 후 조회 성공
- 배포 생성 성공 완료

## 🔗 관련 이슈

- closes #164 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
