### PR TITLE
fix: 쪽지시험 생성 모달 디자인 버그 수정

### DIFF
--- a/src/components/common/input/LogoUpload.tsx
+++ b/src/components/common/input/LogoUpload.tsx
@@ -21,6 +21,8 @@ export default function LogoUpload({
     useImageUpload(onChange)
 
   const logoPreview = preview ?? initialPreview ?? null
+  const shortenFileName = (name: string, max = 20) =>
+    name.length > max ? `${name.slice(0, 10)}...${name.slice(-7)}` : name
 
   return (
     <div className="flex flex-col justify-center gap-3">
@@ -43,12 +45,16 @@ export default function LogoUpload({
           96 x 96 사이즈로 등록하세요.
         </span>
 
-        {fileName && (
-          <span className="text-neutral-400 underline">{fileName}</span>
+        {shortenFileName(fileName) && (
+          <span
+            className="min-w-0 flex-1 overflow-hidden text-[14px] text-ellipsis whitespace-nowrap text-neutral-400 underline"
+            title={shortenFileName(fileName)}
+          >
+            {shortenFileName(fileName)}
+          </span>
         )}
 
         <button
-          type="button"
           className="rounded border border-neutral-200 px-3 py-1 text-[14px] text-neutral-400"
           onClick={handleOpenFile}
         >

--- a/src/features/exams/exam-managements/questions/components/ExamDeletePopupModal.tsx
+++ b/src/features/exams/exam-managements/questions/components/ExamDeletePopupModal.tsx
@@ -5,6 +5,7 @@ type ExamDeletePopupModalProps = {
   isOpen: boolean
   onClose: () => void
   examId: number
+  onDeleted: () => void
 }
 
 /**
@@ -17,9 +18,10 @@ export default function ExamDeletePopupModal({
   isOpen,
   onClose,
   examId,
+  onDeleted,
 }: ExamDeletePopupModalProps) {
   const { mutate: deleteExamRequest, isPending } =
-    useExamDeleteMutation(onClose)
+    useExamDeleteMutation(onDeleted)
 
   const handleExamDeleteClick = () => {
     deleteExamRequest(examId)

--- a/src/features/exams/queries/useExamDeleteMutation.ts
+++ b/src/features/exams/queries/useExamDeleteMutation.ts
@@ -1,16 +1,25 @@
 import { deleteExamRequest } from '@api/exams'
 import { showToast } from '@components'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-export const useExamDeleteMutation = (onClose: () => void) =>
-  useMutation({
+export const useExamDeleteMutation = (onDeleted: () => void) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
     mutationFn: (examId: number) => deleteExamRequest(examId),
 
-    onSuccess: () => {
+    onSuccess: async () => {
       showToast('시험이 삭제되었습니다.', 'success')
 
-      return onClose()
+      onDeleted()
+
+      await queryClient.invalidateQueries({
+        queryKey: ['exams'],
+      })
     },
 
-    onError: () => showToast('시험 삭제 중 오류가 발생했습니다.', 'fail'),
+    onError: () => {
+      showToast('시험 삭제 중 오류가 발생했습니다.', 'fail')
+    },
   })
+}

--- a/src/features/exams/shared/components/detail-modal/ExamQuestionDetailModal.tsx
+++ b/src/features/exams/shared/components/detail-modal/ExamQuestionDetailModal.tsx
@@ -197,6 +197,7 @@ export default function ExamQuestionDetailModal({
             currentIndex={currentIndex}
             onSelect={setCurrentIndex}
             examId={examId}
+            onCloseDetailModal={onClose}
           />
         </ExamQuestionDetailModal.Side>
         <ExamQuestionDetailModal.Body>

--- a/src/features/exams/shared/components/detail-modal/ExamQuestionDetailSide.tsx
+++ b/src/features/exams/shared/components/detail-modal/ExamQuestionDetailSide.tsx
@@ -7,6 +7,7 @@ type ExamQuestionDetailSideProps = {
   currentIndex: number
   onSelect: (index: number) => void
   examId: number
+  onCloseDetailModal: () => void
 }
 
 /**
@@ -21,6 +22,7 @@ export const ExamQuestionDetailSide = ({
   currentIndex,
   onSelect,
   examId,
+  onCloseDetailModal,
 }: ExamQuestionDetailSideProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const handleExamDeletePopupModal = () => {
@@ -56,6 +58,10 @@ export const ExamQuestionDetailSide = ({
         isOpen={isDeleteModalOpen}
         onClose={() => setIsDeleteModalOpen(false)}
         examId={examId}
+        onDeleted={() => {
+          setIsDeleteModalOpen(false)
+          onCloseDetailModal()
+        }}
       />
     </div>
   )

--- a/src/features/exams/shared/hooks/useExamForm.ts
+++ b/src/features/exams/shared/hooks/useExamForm.ts
@@ -48,6 +48,22 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
   const [logoFile, setLogoFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
 
+  const resetForm = () => {
+    setValues({
+      examTitle: '',
+      courseId: '',
+      subjectId: '',
+      thumbnailImg: '',
+    })
+    setLogoFile(null)
+    setPreviewUrl(null)
+  }
+
+  const handleClose = () => {
+    resetForm()
+    onClose()
+  }
+
   const updateValue = (
     key: keyof typeof values,
     value: string | File | null
@@ -79,6 +95,12 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
   )
 
   useEffect(() => {
+    if (modalMode === 'create') {
+      resetForm()
+    }
+  }, [modalMode])
+
+  useEffect(() => {
     if (modalMode === 'update' && examDetail) {
       const parsed = parseExamDetail(examDetail as ExamQuestionResponse)
       const matchedSubject = MOCK_SUBJECT_LIST.find(
@@ -104,10 +126,19 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
     [previewUrl]
   )
 
-  const examCreateMutation = useExamCreateMutation(onClose)
-  const examUpdateMutation = useExamUpdateMutation(onClose)
+  const { mutate: examCreateMutation, isPending: isCreatePending } =
+    useExamCreateMutation(handleClose)
+
+  const { mutate: examUpdateMutation, isPending: isUpdatePending } =
+    useExamUpdateMutation(onClose)
+
+  const isPending = modalMode === 'create' ? isCreatePending : isUpdatePending
 
   const handleSubmit = async () => {
+    if (isPending) {
+      return
+    }
+
     const schemaResult = await examFormSchema.safeParseAsync({
       examTitle: values.examTitle,
       subjectId: values.subjectId,
@@ -131,39 +162,27 @@ export function useExamForm({ modalMode, examId, onClose }: UseExamFormProps) {
         return
       }
 
-      examCreateMutation.mutate({
+      examCreateMutation({
         title: parsed.examTitle,
         subjectId: parsed.subjectId.toString(),
         logoFile,
       })
 
       return
+    } else {
+      if (!examId) {
+        showToast('시험 ID가 없습니다.', 'fail')
+
+        return
+      }
+
+      examUpdateMutation({
+        title: parsed.examTitle,
+        subjectId: parsed.subjectId.toString(),
+        logoFile: logoFile ?? undefined,
+        examId,
+      })
     }
-
-    if (!examId) {
-      showToast('시험 ID가 없습니다.', 'fail')
-
-      return
-    }
-
-    examUpdateMutation.mutate({
-      title: parsed.examTitle,
-      subjectId: parsed.subjectId.toString(),
-      logoFile: logoFile ?? undefined,
-      examId,
-    })
-  }
-
-  const handleClose = () => {
-    setValues({
-      examTitle: '',
-      courseId: '',
-      subjectId: '',
-      thumbnailImg: '',
-    })
-    setLogoFile(null)
-    setPreviewUrl(null)
-    onClose()
   }
 
   const { data: courseRes } = useCourseSubjectsList({ mode: modalMode })


### PR DESCRIPTION
## 📌 작업 내용

- 이미지 이름 길이가 일정 이상 넘지 않게 수정
- 쪽지시험 시험삭제 버튼 클릭 시 목록조회 및 리프래쉬 되도록 수정
- 쪽지시험 생성 버튼 클릭 시 이전 내용 초기화 되도록 수정

## 🔗 관련 이슈

- closes #171 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
