### PR TITLE
fix: 문제 생성 페이지 레이아웃 및 유효성 검사 개선 및 데이터 매핑 오류 수정

### DIFF
--- a/src/components/common/dropdownmenu/DropdownList.tsx
+++ b/src/components/common/dropdownmenu/DropdownList.tsx
@@ -12,7 +12,7 @@ import {
 export type DropdownListProps = {
   id: string
   items: DropdownItem[]
-  selectedValue: string
+  selectedValue: string | undefined
   focusedIndex: number
   onItemClick: (value: string) => void
   onMouseEnterItem: (index: number) => void
@@ -45,7 +45,10 @@ export function DropdownList({
   return (
     <div
       role="listbox"
-      className="absolute top-full left-0 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg"
+      className={cn(
+        'shadow-lg" h-60-xs absolute top-full left-0 mt-1 min-w-full',
+        'overflow-y-auto rounded-md border border-gray-200 bg-white'
+      )}
       tabIndex={-1}
       style={{ zIndex: Z_INDEX.DROPDOWN }}
     >

--- a/src/components/common/dropdownmenu/DropdownMenu.tsx
+++ b/src/components/common/dropdownmenu/DropdownMenu.tsx
@@ -13,7 +13,7 @@ export type DropdownItem = {
 
 export type DropdownMenuProps = {
   items: DropdownItem[]
-  selectedValue: string
+  selectedValue: string | undefined
   onSelect: (value: string) => void
   placeholder?: string
   size?: DropdownSize

--- a/src/components/common/dropdownmenu/dropdownMenuStyle.ts
+++ b/src/components/common/dropdownmenu/dropdownMenuStyle.ts
@@ -29,9 +29,13 @@ export const ICON_SIZE_STYLES: Record<DropdownSize, string> = {
 
 export const getSelectedLabel = (
   items: DropdownItem[],
-  selectedValue: string,
+  selectedValue: string | undefined,
   placeholder?: string
 ) => {
+  if (!selectedValue) {
+    return placeholder ?? ''
+  }
+
   const selectedItem = items.find((item) => item.value === selectedValue)
 
   return selectedItem ? selectedItem.label : placeholder || DEFAULT_MESSAGE

--- a/src/components/common/dropdownmenu/useDropdown.ts
+++ b/src/components/common/dropdownmenu/useDropdown.ts
@@ -14,7 +14,7 @@ import type { DropdownItem } from './DropdownMenu'
 
 type UseDropdownProps = {
   items: DropdownItem[]
-  selectedValue: string
+  selectedValue: string | undefined
   onSelect: (value: string) => void
   buttonRef: RefObject<HTMLButtonElement | null>
 }

--- a/src/features/exams/exam-managements/questions/components/ValidationErrorModal.tsx
+++ b/src/features/exams/exam-managements/questions/components/ValidationErrorModal.tsx
@@ -1,63 +1,24 @@
-import type { ValidationError } from '@features/exams'
-
 import { PopupModal } from '@components'
 
 type ValidationErrorModalProps = {
   isOpen: boolean
   onClose: () => void
-  errors: ValidationError[]
-  onGoToQuestion: (index: number) => void
-}
-
-// 필드명 → 한글 변환
-const getFieldLabel = (field: string): string => {
-  const labels: Record<string, string> = {
-    question: '문제 내용 미입력',
-    correct_answer: '정답 미선택',
-    options: '보기 미입력',
-    point: '배점 미선택',
-  }
-
-  return labels[field] || '입력값 확인 필요'
 }
 
 export default function ValidationErrorModal({
   isOpen,
   onClose,
-  errors,
-  onGoToQuestion,
 }: ValidationErrorModalProps) {
-  const handleGoToQuestion = (index: number) => {
-    onGoToQuestion(index)
-
-    return onClose()
-  }
-
   return (
     <PopupModal isOpen={isOpen} onClose={onClose}>
       <PopupModal.Icon variant="danger" />
       <PopupModal.Title>아직 입력하지 않은 문제가 있습니다</PopupModal.Title>
       <PopupModal.Description>
-        <ul className="mt-2 space-y-1 text-left text-sm">
-          {errors.map((error, idx) => (
-            <li key={idx} className="flex items-center justify-between">
-              <span className="text-neutral-600">
-                • {error.questionIndex + 1}번 문제: {getFieldLabel(error.field)}
-              </span>
-              <button
-                type="button"
-                onClick={() => handleGoToQuestion(error.questionIndex)}
-                className="text-primary-500 hover:underline"
-              >
-                이동
-              </button>
-            </li>
-          ))}
-        </ul>
+        빨간색으로 표시된 문제의 필수 항목을 입력해주세요.
       </PopupModal.Description>
       <PopupModal.ButtonArea>
         <PopupModal.PopupButton variant="secondary" onClick={onClose}>
-          닫기
+          확인
         </PopupModal.PopupButton>
       </PopupModal.ButtonArea>
     </PopupModal>

--- a/src/features/exams/exam-managements/questions/components/question-form/FillBlankQuestionForm.tsx
+++ b/src/features/exams/exam-managements/questions/components/question-form/FillBlankQuestionForm.tsx
@@ -39,8 +39,8 @@ export default function FillBlankForm() {
   }
 
   return (
-    <section className="flex h-full flex-col gap-4">
-      <div className="mb-4">
+    <section className="flex flex-col gap-6">
+      <div>
         <QuestionTypeSelect
           value={current.type}
           onChange={(type) => {
@@ -58,7 +58,7 @@ export default function FillBlankForm() {
             updateCurrentQuestion({ question: value })
           }}
         />
-        <div className="mb-4 flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <label
             htmlFor={pointId}
             className="invisible text-lg font-medium text-neutral-500"

--- a/src/features/exams/exam-managements/questions/components/question-form/MultipleChoiceQuestionForm.tsx
+++ b/src/features/exams/exam-managements/questions/components/question-form/MultipleChoiceQuestionForm.tsx
@@ -43,8 +43,8 @@ export default function MultipleChoiceForm() {
     : []
 
   return (
-    <section className="fex h-full flex-col gap-4">
-      <div className="mb-4">
+    <section className="flex flex-col gap-6">
+      <div>
         <QuestionTypeSelect
           value={currentQuestion.type}
           onChange={(type) => handleTypeChange(type)}

--- a/src/features/exams/exam-managements/questions/components/question-form/OrderingQuestionForm.tsx
+++ b/src/features/exams/exam-managements/questions/components/question-form/OrderingQuestionForm.tsx
@@ -38,12 +38,14 @@ export default function OrderingQuestionForm() {
   }
 
   // 기본값 설정
-  const options = current.options || ['', '']
-  const correctAnswer = current.correct_answer || [0, 1]
+  const options = current.options?.length ? current.options : ['', '', '', '']
+  const correctAnswer = current.correct_answer?.length
+    ? current.correct_answer
+    : [0, 1, 2, 3]
 
   return (
-    <section className="flex h-full flex-col gap-4">
-      <div className="mb-4">
+    <section className="flex flex-col gap-6">
+      <div>
         <QuestionTypeSelect
           value={current.type}
           onChange={(type) => {
@@ -61,7 +63,8 @@ export default function OrderingQuestionForm() {
             updateCurrentQuestion({ question: value })
           }}
         />
-        <div className="mb-4 flex flex-col gap-1">
+
+        <div className="flex flex-col gap-1">
           <label
             htmlFor={pointId}
             className="invisible text-lg font-medium text-neutral-500"
@@ -77,7 +80,6 @@ export default function OrderingQuestionForm() {
         </div>
       </div>
 
-      {/* 보기 & 순서 에디터 + 해설 */}
       <div className="flex gap-6">
         <div className="w-1/2">
           <OrderingEditor

--- a/src/features/exams/exam-managements/questions/components/question-form/OxQuestionForm.tsx
+++ b/src/features/exams/exam-managements/questions/components/question-form/OxQuestionForm.tsx
@@ -1,5 +1,4 @@
 import { createEmptyQuestion } from '@stores/question/helpers'
-import { useId } from 'react'
 
 import type { Question, QuestionType } from '../../types'
 
@@ -19,8 +18,6 @@ export default function OxQuestionForm() {
   const { current, updateCurrentQuestion, replaceQuestion, currentIndex } =
     useQuestionForm()
 
-  const pointId = useId()
-
   const isOxQuestion = (
     q: Question
   ): q is Question & { type: 'ox'; correct_answer?: boolean } => q.type === 'ox'
@@ -33,8 +30,8 @@ export default function OxQuestionForm() {
     replaceQuestion(currentIndex, createEmptyQuestion(type))
 
   return (
-    <section className="flex h-full flex-col gap-4">
-      <div className="mb-4">
+    <section className="flex flex-col gap-6">
+      <div>
         <QuestionTypeSelect
           value={current.type}
           onChange={(type) => handleTypeChange(type)}
@@ -48,13 +45,11 @@ export default function OxQuestionForm() {
           value={current.question}
           onChange={(value) => updateCurrentQuestion({ question: value })}
         />
-        <div className="mb-4 flex flex-col gap-1">
-          <label
-            htmlFor={pointId}
-            className="invisible text-lg font-medium text-neutral-500"
-          >
+
+        <div className="flex flex-col gap-1">
+          <span className="invisible text-lg font-medium text-neutral-500">
             배점
-          </label>
+          </span>
           <PointSelect
             value={current.point}
             onChange={(point) => updateCurrentQuestion({ point })}

--- a/src/features/exams/exam-managements/questions/components/question-form/ShortAnswerQuestionForm.tsx
+++ b/src/features/exams/exam-managements/questions/components/question-form/ShortAnswerQuestionForm.tsx
@@ -36,8 +36,8 @@ export default function ShortAnswerQuestionForm() {
   }
 
   return (
-    <section className="fex h-full flex-col gap-4">
-      <div className="mb-6">
+    <section className="flex flex-col gap-6">
+      <div>
         <QuestionTypeSelect
           value={current.type}
           onChange={handleTypeChange}
@@ -54,7 +54,7 @@ export default function ShortAnswerQuestionForm() {
           }}
         />
 
-        <div className="mb-6 flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <label
             htmlFor={pointId}
             className="invisible text-lg font-medium text-neutral-500"

--- a/src/features/exams/exam-managements/questions/hooks/useCreateQuestion.ts
+++ b/src/features/exams/exam-managements/questions/hooks/useCreateQuestion.ts
@@ -66,6 +66,8 @@ export function useCreateQuestion() {
 
     await saveAll()
 
+    reset()
+
     return navigate(ROUTES_PATHS.EXAM)
   }
 
@@ -129,6 +131,15 @@ export function useCreateQuestion() {
       return addQuestion('multiple_choice')
     }
   }
+
+  // 문제 수정 시 해당 에러 제거
+  useEffect(() => {
+    if (validationErrors.length > 0) {
+      setValidationErrors((prev) =>
+        prev.filter((error) => error.questionIndex !== currentIndex)
+      )
+    }
+  }, [questions, currentIndex, validationErrors.length])
 
   return {
     examId,

--- a/src/features/exams/exam-managements/questions/queries/useQuestionMutation.ts
+++ b/src/features/exams/exam-managements/questions/queries/useQuestionMutation.ts
@@ -25,6 +25,7 @@ export function useSaveAllQuestions() {
     onSuccess: () => {
       showToast('문제가 저장되었습니다.', 'success')
       queryClient.invalidateQueries({ queryKey: ['exam', examId] })
+      queryClient.invalidateQueries({ queryKey: ['exams'] })
       reset()
     },
 

--- a/src/features/exams/exam-managements/questions/question-inputs/PointSelect.tsx
+++ b/src/features/exams/exam-managements/questions/question-inputs/PointSelect.tsx
@@ -14,7 +14,7 @@ const POINT_OPTIONS: DropdownItem[] = [
 ]
 
 type PointSelectProps = {
-  value: number
+  value: number | null
   onChange: (point: number) => void
   className?: string
 }
@@ -30,7 +30,7 @@ export default function PointSelect({
   return (
     <DropdownMenu
       items={POINT_OPTIONS}
-      selectedValue={String(value)}
+      selectedValue={value !== null ? String(value) : undefined}
       onSelect={(v) => {
         onChange(Number(v))
       }}

--- a/src/features/exams/exam-managements/questions/types.ts
+++ b/src/features/exams/exam-managements/questions/types.ts
@@ -17,7 +17,7 @@ export type Question = {
   options: string[] | null
   blank_count: number | null
   correct_answer: string | string[] | number | number[] | boolean
-  point: number
+  point: number | null
   explanation: string
 }
 

--- a/src/features/exams/index.ts
+++ b/src/features/exams/index.ts
@@ -79,3 +79,4 @@ export { default as CreateQuestionFooter } from './exam-managements/questions/co
 export { default as QuestionDeletePopupModal } from './exam-managements/questions/components/QuestionDeletPopupModal.tsx'
 export { default as ValidationErrorModal } from './exam-managements/questions/components/ValidationErrorModal.tsx'
 export { formatDate } from './utils/formatDate'
+export { useCreateQuestion } from './exam-managements/questions/hooks/useCreateQuestion'

--- a/src/features/exams/shared/components/QuestionNav.tsx
+++ b/src/features/exams/shared/components/QuestionNav.tsx
@@ -8,24 +8,34 @@ type QuestionNavProps = {
   mode?: 'create' | 'submission'
   actionButton?: React.ReactNode
   className?: string
+  errorIndexes?: number[]
 }
 
-/**
- * 문제 네비게이션
- * @param actionButton - 문제추가, 시험삭제 등
- */
 export default function QuestionNav({
   mode = 'create',
   actionButton,
   className,
+  errorIndexes = [],
 }: QuestionNavProps) {
   const { questions, currentIndex, deleteQuestion, setCurrentIndex } =
     useQuestionStore()
 
   const getButtonStyle = (index: number, question: Question) => {
     const isSelected = currentIndex === index
+    const hasError = errorIndexes.includes(index)
 
     if (mode === 'create') {
+      // 에러 있는 문제
+      if (hasError) {
+        return cn(
+          'ring-2 ring-red-500',
+          isSelected
+            ? 'bg-red-500 text-white'
+            : 'bg-red-50 text-red-500 hover:bg-red-100'
+        )
+      }
+
+      // 정상 문제
       return cn(
         isSelected
           ? 'bg-primary-400 text-white'
@@ -33,6 +43,7 @@ export default function QuestionNav({
       )
     }
 
+    // submission 모드
     const isCorrect =
       'isCorrect' in question
         ? (question as unknown as SubmissionQuestion).isCorrect
@@ -79,8 +90,8 @@ export default function QuestionNav({
                 onClick={(e) => handleDelete(e, index)}
                 className={cn(
                   'absolute -top-1 -right-1 hidden h-4 w-4 items-center justify-center',
-                  'rounded-full bg-gray-400 text-white group-hover:flex hover:bg-gray-500',
-                  'hidden group-hover:flex'
+                  'rounded-full bg-gray-400 text-white hover:bg-gray-500',
+                  'group-hover:flex'
                 )}
               >
                 <CancelIcon className="h-3 w-3" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -38,7 +38,9 @@ enableMocking().then(() => {
         <BrowserRouter>
           <App />
         </BrowserRouter>
-        <ReactQueryDevtools initialIsOpen={false} />
+        {process.env.NODE_ENV === 'development' && (
+          <ReactQueryDevtools initialIsOpen={false} />
+        )}
       </QueryClientProvider>
     </StrictMode>
   )

--- a/src/pages/CreateQuestionPage.tsx
+++ b/src/pages/CreateQuestionPage.tsx
@@ -7,11 +7,10 @@ import {
   getQuestionForm,
   QuestionDeletePopupModal,
   QuestionNav,
+  useCreateQuestion,
   ValidationErrorModal,
 } from '@features/exams'
 import { cn } from '@utils'
-
-import { useCreateQuestion } from '../features/exams/exam-managements/questions/hooks/useCreateQuestion'
 
 export default function CreateQuestionPage() {
   const {
@@ -24,7 +23,6 @@ export default function CreateQuestionPage() {
     isValidationModalOpen,
     validationErrors,
     handleValidationModalClose,
-    handleGoToQuestion,
     handleComplete,
     handleCancel,
     handleEdit,
@@ -43,18 +41,23 @@ export default function CreateQuestionPage() {
     return <div>시험 정보를 찾을 수 없습니다.</div>
   }
 
+  // 에러가 있는 문제 인덱스 추출 (중복 제거)
+  const errorQuestionIndexes = [
+    ...new Set(validationErrors.map((e) => e.questionIndex)),
+  ]
+
   return (
     <>
-      <section className="px-15 py-11">
-        <div className="h-192 bg-white px-18 py-8">
+      <section className="px-6 py-8">
+        <div className="bg-white px-8 py-6">
           <CreateQuestionHeader
             onGoToList={handleCancel}
             onEdit={handleEdit}
             onDelete={handleDeleteClick}
           />
 
-          <div className="relative flex max-h-174 max-w-353 flex-col overflow-hidden bg-neutral-100 px-8 py-7">
-            <div className="mb-4 flex items-center gap-3">
+          <div className="flex h-175 flex-col bg-neutral-100 px-8 py-6">
+            <div className="mb-4 flex shrink-0 items-center gap-3">
               <img
                 src={examDetail?.thumbnailImgUrl || DEFAULT_THUMBNAIL_IMG}
                 alt={examDetail?.title || ''}
@@ -69,27 +72,31 @@ export default function CreateQuestionPage() {
               </div>
             </div>
 
-            <main className="flex flex-1 gap-6 overflow-y-auto">
-              <QuestionNav
-                actionButton={
-                  <Button
-                    variant="primary-outline"
-                    size="action"
-                    onClick={handleAddQuestion}
-                    className="w-full"
-                    disabled={questions.length >= 20}
-                  >
-                    문제 추가
-                  </Button>
-                }
-              />
-              <div className="max-h-125 max-w-225 flex-1 overflow-y-auto rounded-lg bg-white p-6 shadow-sm">
+            <main className="flex min-h-0 flex-1 gap-6">
+              <div className="shrink-0">
+                <QuestionNav
+                  actionButton={
+                    <Button
+                      variant="primary-outline"
+                      size="action"
+                      onClick={handleAddQuestion}
+                      className="w-full"
+                      disabled={questions.length >= 20}
+                    >
+                      문제 추가
+                    </Button>
+                  }
+                  errorIndexes={errorQuestionIndexes}
+                />
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-white p-6 shadow-sm">
                 {QuestionForm ? (
                   <QuestionForm />
                 ) : (
                   <div
                     className={cn(
-                      'flex flex-1 items-center justify-center',
+                      'flex h-full items-center justify-center',
                       'rounded-lg border border-primary-100 p-6'
                     )}
                   >
@@ -99,13 +106,15 @@ export default function CreateQuestionPage() {
               </div>
             </main>
 
-            <CreateQuestionFooter
-              currentIndex={currentIndex}
-              totalCount={questions.length}
-              isPending={isPending}
-              onCancel={handleCancel}
-              onComplete={handleComplete}
-            />
+            <div className="shrink-0">
+              <CreateQuestionFooter
+                currentIndex={currentIndex}
+                totalCount={questions.length}
+                isPending={isPending}
+                onCancel={handleCancel}
+                onComplete={handleComplete}
+              />
+            </div>
           </div>
         </div>
       </section>
@@ -120,8 +129,6 @@ export default function CreateQuestionPage() {
       <ValidationErrorModal
         isOpen={isValidationModalOpen}
         onClose={handleValidationModalClose}
-        errors={validationErrors}
-        onGoToQuestion={handleGoToQuestion}
       />
     </>
   )

--- a/src/stores/question/helpers.ts
+++ b/src/stores/question/helpers.ts
@@ -26,7 +26,7 @@ export const createEmptyQuestion = (type: QuestionType): Question => {
     question: '',
     prompt: '',
     explanation: '',
-    point: 10,
+    point: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   }

--- a/src/stores/question/useQuestionStore.tsx
+++ b/src/stores/question/useQuestionStore.tsx
@@ -93,6 +93,7 @@ export const useQuestionStore = create<QuestionState>()(
         return questions.map(({ id: _id, updatedAt: _updatedAt, ...rest }) => ({
           exam_id: examId,
           ...rest,
+          point: rest.point ?? 10,
         }))
       },
     }),


### PR DESCRIPTION
## 📌 작업 내용

-  문제 영역 컨테이너 넘침 (스크롤 처리 필요)
-  ValidationErrorModal 에러 목록이 너무 길어짐
- 유효성 에러 표시 후 수정해도 빨간색 유지됨
- QuestionTypeSelect 드롭다운 너비 문제 (일부 유형)
- 문제 저장 후 목록 미갱신
- 팝업모달 생성 후 재오픈 시 이전데이터 잔존
- 문제 저장 후 목록 미갱신(React Query 캐시 무효화 누락)

## 🔗 관련 이슈

- closes #176 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
